### PR TITLE
Fix validation failed

### DIFF
--- a/lib/api/login.js
+++ b/lib/api/login.js
@@ -73,7 +73,9 @@ var login = module.exports = function (callback) {
             }
         }
 
-        return CONFIG._github.authorization.create(opts, function (err, res) {
+        return CONFIG._github.authorization.getAll({
+            headers: (opts.headers ? opts.headers : {})
+        }, function (err, res) {
             if (err) {
                 var error;
                 try {
@@ -93,8 +95,29 @@ var login = module.exports = function (callback) {
                 }
             }
 
-            CONFIG.token = res.token;
-            login(callback);
+            var cliAuth;
+            for (var i = 0; i < res.length; ++i) {
+                var auth = res[i];
+
+                if (auth.note === "CLI GitHub") {
+                    cliAuth = auth;
+                    break;
+                } else {
+                    continue;
+                }
+            }
+
+            if (typeof cliAuth !== "undefined") {
+                CONFIG.token = cliAuth.token;
+                login(callback);
+            } else {
+                CONFIG._github.authorization.create(opts, function (err, res) {
+                    if (err) return callback(err);
+
+                    CONFIG.token = res.token;
+                    login(callback);
+                });
+            }
         });
     }
 


### PR DESCRIPTION
The login process will now check the account's previous authorizations, and see if a token was made for CLI GitHub already. If there was, we use that, so we don't have to generate a new one! :smile: 

Fixes #7.
